### PR TITLE
chore: add gitattributes config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# We'll let Git's auto-detection algorithm infer if a file is text. If it is,
+# enforce LF line endings regardless of OS or git configurations.
+* text=auto eol=lf
+
+# Isolate binary files in case the auto-detection algorithm fails and
+# marks them as text files (which could brick them).
+*.{png,jpg,jpeg,gif,webp,woff,woff2} binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,10 @@
-# We'll let Git's auto-detection algorithm infer if a file is text. If it is,
-# enforce LF line endings regardless of OS or git configurations.
+# Auto detect text files and perform LF normalization
 * text=auto eol=lf
 
-# Isolate binary files in case the auto-detection algorithm fails and
-# marks them as text files (which could brick them).
+# These files should have specific line endings
+*.sh	text eol=lf
+*.bat	text eol=crlf
+
+# These files are binary and should be left untouched in case the auto-detection algorithm fails
+# (binary is a macro for -text -diff)
 *.{png,jpg,jpeg,gif,webp,woff,woff2} binary


### PR DESCRIPTION
### Requirements

#### Definition of Done
**Mandatory for all PRs** 
- [x] All unit and build tests are green 🚦 
- [ ] Reviewed and approved by maintainer :+1:

### Description of the Change

- Git config: `LF` style end of line

### Why should this be in the library?

Git should support developers in maintaining `LF` style end of line to avoid inconsistency issues with Windows machines
