### PR TITLE
fix: add a title attribute for formfield

### DIFF
--- a/projects/ng-aquila/src/formfield/formfield.component.html
+++ b/projects/ng-aquila/src/formfield/formfield.component.html
@@ -28,7 +28,7 @@ We are building the following structure.
           <ng-content select="[nxFormfieldPrefix]"></ng-content>
         </div>
 
-        <div class="nx-formfield__input">
+        <div class="nx-formfield__input" [title]="label">
           <!-- This handles the floating whole behavior -->
           <span class="nx-formfield__label-holder">
             <label class="nx-formfield__label" [id]="labelId" [attr.aria-owns]="_control.id"


### PR DESCRIPTION
I added an html attribute title for the form field component to conveniently display the nxLabel value if its title is very long. 
I mean "sooooooooooooooooooooooooooooooooooo long".
I see only a truncated title and 3 dots, in this case it is not clear what is written there 